### PR TITLE
Cleanly supports executing and publishing wrapped function

### DIFF
--- a/recommendersystem/recommender/management/commands/test_producer.py
+++ b/recommendersystem/recommender/management/commands/test_producer.py
@@ -8,4 +8,4 @@ class Command(BaseCommand):
         'publish messages to queues.'
 
     def handle(self, *args, **options):
-        empty_func(2, 10)
+        empty_func.publish(2, 10)

--- a/recommendersystem/recommender/queue/worker.py
+++ b/recommendersystem/recommender/queue/worker.py
@@ -32,4 +32,4 @@ class Worker(ConsumerMixin):
         module, task = body['function'].rsplit('.', 1)
         module = importlib.import_module(module)
         callable = getattr(module, task, None)
-        return callable._original
+        return callable.execute


### PR DESCRIPTION
Previously, the wrapped function execution was hacked together to store the unmodified decorated function in the decorated result.

This merge splits the publish and execute functionality into two distinct functions that are added to the decorated function: publish (to put the task on the queue for later execution) and execute (to immediately run the task).  The function called depends on whether the published or consumer is handling the message.